### PR TITLE
A constructor for QueryDslJdbcTemplate to override and fine tune the QueryDSL dialect

### DIFF
--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/query/QueryDslJdbcTemplate.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/query/QueryDslJdbcTemplate.java
@@ -114,6 +114,11 @@ public class QueryDslJdbcTemplate implements QueryDslJdbcOperations {
 		}
 	}
 
+    public QueryDslJdbcTemplate(JdbcTemplate jdbcTemplate, SQLTemplates dialect) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dialect = dialect;
+    }
+
 	public JdbcOperations getJdbcOperations() {
 		return this.jdbcTemplate;
 	}

--- a/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/query/QueryDslTemplateConstructionTest.java
+++ b/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/query/QueryDslTemplateConstructionTest.java
@@ -1,0 +1,42 @@
+package org.springframework.data.jdbc.query;
+
+import com.mysema.query.sql.HSQLDBTemplates;
+import com.mysema.query.sql.SQLTemplates;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jdbc.query.generated.QCustomer;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.sql.DataSource;
+
+import static org.junit.Assert.assertEquals;
+
+@ContextConfiguration(locations="classpath:query-dsl-context.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class QueryDslTemplateConstructionTest {
+
+    private final QCustomer qCustomer = QCustomer.customer;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    public void testPrintSchema() {
+        SQLTemplates dialectWithSchema = HSQLDBTemplates.builder().printSchema().build();
+        SQLTemplates dialectWithoutSchema = HSQLDBTemplates.builder().build();
+        QueryDslJdbcTemplate templateWithSchema = new QueryDslJdbcTemplate(jdbcTemplate, dialectWithSchema);
+        QueryDslJdbcTemplate templateWithoutSchema = new QueryDslJdbcTemplate(jdbcTemplate, dialectWithoutSchema);
+        assertEquals("from PUBLIC.CUSTOMER CUSTOMER", templateWithSchema.newSqlQuery().from(qCustomer).toString());
+        assertEquals("from CUSTOMER CUSTOMER", templateWithoutSchema.newSqlQuery().from(qCustomer).toString());
+    }
+
+}


### PR DESCRIPTION
Added a unit test for the constructor

In my use case, I need this constructor to make QueryDSL put schema names in the generated SQL. I believe this PR should help resolve https://jira.springsource.org/browse/DATAJDBC-40 as well since SQLTemplates interface supports 'quote' as a boolean property.
