### PR TITLE
STRUCT and ARRAY types are deprecated. 

### DIFF
--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/StructDatumMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/StructDatumMapper.java
@@ -69,11 +69,12 @@ public class StructDatumMapper<T> implements DatumMapper<T> {
     public StructDatumMapper(String typeName, Class<T> targetClass) {
         this.typeName = typeName;
         this.mapper = new BeanPropertyStructMapper<T>(targetClass);
+
     }
 
 
     public Datum toDatum(T source, Connection conn) throws SQLException {
-        STRUCT struct = mapper.toStruct(source, conn, typeName);
+        STRUCT struct = (STRUCT) mapper.toStruct(source, conn, typeName);
         return struct;
     }
 

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/BeanPropertyStructMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/BeanPropertyStructMapper.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
 import java.beans.PropertyDescriptor;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Struct;
 import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
@@ -154,7 +155,7 @@ public class BeanPropertyStructMapper<T> implements StructMapper<T> {
 	}
 
 
-    public STRUCT toStruct(T source, Connection conn, String typeName) throws SQLException {
+    public Struct toStruct(T source, Connection conn, String typeName) throws SQLException {
         StructDescriptor descriptor = new StructDescriptor(typeName, conn);
         ResultSetMetaData rsmd = descriptor.getMetaData();
         int columns = rsmd.getColumnCount();
@@ -193,13 +194,13 @@ public class BeanPropertyStructMapper<T> implements StructMapper<T> {
 	 * <p>Utilizes public setters and result set metadata.
 	 * @see java.sql.ResultSetMetaData
 	 */
-	public T fromStruct(STRUCT struct) throws SQLException {
+	public T fromStruct(Struct struct) throws SQLException {
         Assert.state(this.mappedClass != null, "Mapped class was not specified");
         T mappedObject = BeanUtils.instantiateClass(this.mappedClass);
         BeanWrapper bw = PropertyAccessorFactory.forBeanPropertyAccess(mappedObject);
         initBeanWrapper(bw);
-
-        ResultSetMetaData rsmd = struct.getDescriptor().getMetaData();
+        
+        ResultSetMetaData rsmd = ((STRUCT) struct).getDescriptor().getMetaData();
         Object[] attr = struct.getAttributes();
         int columnCount = rsmd.getColumnCount();
         for (int index = 1; index <= columnCount; index++) {

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyDataSource.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyDataSource.java
@@ -23,6 +23,8 @@ import org.springframework.jdbc.datasource.SmartDataSource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 import java.io.PrintWriter;
 
 import javax.sql.DataSource;
@@ -92,4 +94,11 @@ public class ProxyDataSource implements SmartDataSource {
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         return ((DataSource)oracleDataSurce).isWrapperFor(iface);
     }
+
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructArrayValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructArrayValue.java
@@ -16,14 +16,14 @@
 
 package org.springframework.data.jdbc.support.oracle;
 
-import oracle.sql.ARRAY;
-import oracle.sql.ArrayDescriptor;
-import oracle.sql.STRUCT;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.jdbc.core.support.AbstractSqlTypeValue;
 
+import oracle.jdbc.driver.OracleConnection;
+
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Struct;
 
 /**
  * Implementation of the SqlTypeValue interface, for convenient
@@ -103,12 +103,11 @@ public class SqlStructArrayValue<T> extends AbstractSqlTypeValue {
 			throw new InvalidDataAccessApiUsageException(
 					"The typeName for the array is null in this context. Consider setting the arrayTypeName.");
 		}
-        ArrayDescriptor arrayDescriptor = new ArrayDescriptor(typeName != null ? typeName : arrayTypeName, conn);
-		STRUCT[] structValues = new STRUCT[values.length];
+		Struct[] structValues = new Struct[values.length];
 		for (int i = 0; i < values.length; i++) {
 			structValues[i] = mapper.toStruct(values[i], conn, structTypeName);
 		}
-        ARRAY array = new ARRAY(arrayDescriptor, conn, structValues);
-        return array;
+		OracleConnection oracleConn = (OracleConnection) conn;
+		return oracleConn.createOracleArray(typeName != null ? typeName : arrayTypeName, structValues);
     }
 }

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StructMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StructMapper.java
@@ -16,10 +16,9 @@
 
 package org.springframework.data.jdbc.support.oracle;
 
-import oracle.sql.STRUCT;
-
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Struct;
 
 /**
  * Interface defining signatures needed for pluggable implementations of STRUCT mappers.
@@ -38,7 +37,7 @@ public interface StructMapper<T> {
      * @return the new STRUCT
      * @throws SQLException
      */
-    STRUCT toStruct(T source, Connection conn, String typeName) throws SQLException;
+    Struct toStruct(T source, Connection conn, String typeName) throws SQLException;
 
     /**
      * Map attributes from the passed in STRUCT to the desired object type.
@@ -46,5 +45,5 @@ public interface StructMapper<T> {
      * @return new instance of the target class populated with attribute values
      * @throws SQLException
      */
-    T fromStruct(STRUCT struct) throws SQLException;
+    T fromStruct(Struct struct) throws SQLException;
 }


### PR DESCRIPTION
STRUCT and ARRAY types are deprecated. Migration to java.sql.Struct and java.sql.Array-Types.
(This is my very first try to contribute  ;-)   )