### PR TITLE
Add equality-check to avoid eternal loop.

### DIFF
--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractor.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractor.java
@@ -93,7 +93,8 @@ public abstract class OneToManyResultSetExtractor<R, C, K> implements ResultSetE
 		while (more) {
 			R root = rootMapper.mapRow(rs, row);
 			K primaryKey = mapPrimaryKey(rs);
-			if (mapForeignKey(rs) != null) {
+			K foreignKey = mapForeignKey(rs);
+			if (foreignKey != null && primaryKey.equals(foreignKey)) {
 				while (more && primaryKey.equals(mapForeignKey(rs))) {
 					addChild(root, childMapper.mapRow(rs, row));
 					more = rs.next();

--- a/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractorTest.java
+++ b/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractorTest.java
@@ -94,12 +94,7 @@ public class OneToManyResultSetExtractorTest {
 
 		@Override
 		protected Integer mapForeignKey(ResultSet rs) throws SQLException {
-			if (rs.getObject("address.customer_id") == null) {
-				return null;
-			}
-			else {
-				return rs.getInt("address.customer_id");
-			}
+			return rs.getInt("address.customer_id");
 		}
 
 		@Override


### PR DESCRIPTION
We had a problem where our implementation returned a Long primary/foreign key using rs.getLong("xx"). Since this returns a primitive 0 when the column is NULL the code executed an eternal loop adding millions of objects until we ran out of memory.

The fix is easy enough - add a null-check or rs.wasNull() or similar. But it was hard to track down.

This pull request suggests adding a check to see if the keys are equal before starting to loop for children. To avoid the situation described above.
