### PR TITLE
Fixed issue with custom datasource for xml types

### DIFF
--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeValue.java
@@ -16,6 +16,7 @@
 
 package org.springframework.data.jdbc.support.oracle;
 
+import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleTypes;
 import oracle.xdb.XMLType;
 
@@ -73,7 +74,7 @@ public class OracleXmlTypeValue implements SqlXmlValue {
         this.value = value;
         inputType = STRING;
     }
-    
+
     /**
      * Constructor that takes one parameter with the XML InputStream passed in to be used.
      * @param stream the <code>InputStream</code> containing the XML to use.
@@ -101,6 +102,13 @@ public class OracleXmlTypeValue implements SqlXmlValue {
      */
     public void setValue(PreparedStatement ps, int paramIndex) throws SQLException {
         Connection conn = ps.getConnection();
+
+        if (!(conn instanceof OracleConnection)) {
+            if (conn.isWrapperFor(OracleConnection.class)) {
+                conn = conn.unwrap(OracleConnection.class);
+            }
+        }
+
         switch (inputType) {
             case STRING:
                 xmlValue = XMLType.createXML(conn, value);


### PR DESCRIPTION
Good day!  

I don't really know if there any process for contribution of this project. So i just fixed this project for my needs. Maybe i would be useful for somebody)  

-----

The main problem was in HikariDataSource and Oracle "SYS.XMLTYPE", they doesn't work together in my case. I tried to create StoredProcedure with SqlParameter and got exception:
java.lang.ClassCastException: com.zaxxer.hikari.pool.HikariProxyConnection cannot be cast to oracle.jdbc.OracleConnection