### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
@@ -30,7 +30,7 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven { url "http://repo.spring.io/libs-milestone" }
+    maven { url "https://repo.spring.io/libs-milestone" }
   }
 
 }
@@ -56,8 +56,8 @@ configure(subprojects) { subproject ->
   }
 
   javadoc.options.links =
-    ["http://static.springframework.org/spring/docs/3.0.x/javadoc-api",
-     "http://download.oracle.com/javase/6/docs/api"]
+    ["https://docs.spring.io/spring/docs/3.0.x/javadoc-api",
+     "https://download.oracle.com/javase/6/docs/api"]
 
   task javadocJar(type: Jar) {
     classifier = "javadoc"
@@ -121,8 +121,8 @@ configure(rootProject) {
         options.overview = 'docs/src/api/overview.html'
         options.splitIndex = true
         options.links =
-          ["http://static.springframework.org/spring/docs/3.0.x/javadoc-api",
-           "http://download.oracle.com/javase/6/docs/api"]
+          ["https://docs.spring.io/spring/docs/3.0.x/javadoc-api",
+           "https://download.oracle.com/javase/6/docs/api"]
         source subprojects.collect { project ->
             project.sourceSets.main.allJava
         }

--- a/maven.gradle
+++ b/maven.gradle
@@ -31,20 +31,20 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://github.com/spring-projects/spring-data-jdbc-ext'
+            url = 'https://github.com/spring-projects/spring-data-jdbc-ext'
             organization {
                 name = 'Spring by Pivotal'
-                url = 'http://spring.io'
+                url = 'https://spring.io'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }
             scm {
-                url = 'http://github.com/spring-projects/spring-data-jdbc-ext'
+                url = 'https://github.com/spring-projects/spring-data-jdbc-ext'
                 connection = 'scm:git:git://github.com/spring-projects/spring-data-jdbc-ext'
                 developerConnection = 'scm:git:git://github.com/spring-projects/spring-data-jdbc-ext'
             }

--- a/spring-data-oracle-test/build.gradle
+++ b/spring-data-oracle-test/build.gradle
@@ -14,9 +14,9 @@ test {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url "http://repo.spring.io/milestone" }
-  maven { url "http://repo.spring.io/release" }
-  maven { url "http://repo.spring.io/ext-private-local" }
+  maven { url "https://repo.spring.io/milestone" }
+  maven { url "https://repo.spring.io/release" }
+  maven { url "https://repo.spring.io/ext-private-local" }
 }
 
 dependencies {

--- a/spring-data-oracle/build.gradle
+++ b/spring-data-oracle/build.gradle
@@ -7,7 +7,7 @@ test {
 
 repositories {
   mavenLocal()
-  maven { url "http://repo.spring.io/ext-private-local" }
+  maven { url "https://repo.spring.io/ext-private-local" }
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://github.com/spring-projects/spring-data-jdbc-ext migrated to:  
  https://github.com/spring-projects/spring-data-jdbc-ext ([https](https://github.com/spring-projects/spring-data-jdbc-ext) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring/docs/3.0.x/javadoc-api (301) migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.0.x/javadoc-api) result 301).
* http://download.oracle.com/javase/6/docs/api migrated to:  
  https://download.oracle.com/javase/6/docs/api ([https](https://download.oracle.com/javase/6/docs/api) result 302).
* http://repo.spring.io/ext-private-local migrated to:  
  https://repo.spring.io/ext-private-local ([https](https://repo.spring.io/ext-private-local) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).