### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/info/license.txt
+++ b/docs/src/info/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/src/reference/docbook/styles/html/custom.xsl
+++ b/docs/src/reference/docbook/styles/html/custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/src/reference/docbook/styles/html/titlepage.xml
+++ b/docs/src/reference/docbook/styles/html/titlepage.xml
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/src/reference/docbook/styles/pdf/custom.xsl
+++ b/docs/src/reference/docbook/styles/pdf/custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/src/reference/docbook/styles/pdf/titlepage.xml
+++ b/docs/src/reference/docbook/styles/pdf/titlepage.xml
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/aop/ConnectionInterceptor.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/aop/ConnectionInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractor.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/retry/JdbcRetryException.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/retry/JdbcRetryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/retry/JdbcRetryPolicy.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/retry/JdbcRetryPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionContextProvider.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionContextProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionPreparer.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionPreparer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionUsernamePasswordProvider.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionUsernamePasswordProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionUsernameProvider.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/ConnectionUsernameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/DatabaseType.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/DatabaseType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/nativejdbc/P6spyNativeJdbcExtractor.java
+++ b/spring-data-jdbc-core/src/main/java/org/springframework/data/jdbc/support/nativejdbc/P6spyNativeJdbcExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractorTest.java
+++ b/spring-data-jdbc-core/src/test/java/org/springframework/data/jdbc/core/OneToManyResultSetExtractorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/AqJmsConnectionFactoryBeanDefinitionParser.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/AqJmsConnectionFactoryBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/AqJmsFactoryBeanFactory.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/AqJmsFactoryBeanFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/DataOrclNamespaceHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/DataOrclNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/OracleConnectionProxy.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/OracleConnectionProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/PoolingDataSourceBeanDefinitionParser.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/PoolingDataSourceBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/RacFailoverInterceptorBeanDefinitionParser.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/config/oracle/RacFailoverInterceptorBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/listener/oracle/AdtMessageListenerContainer.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/listener/oracle/AdtMessageListenerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/listener/oracle/XmlMessageListenerContainer.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/listener/oracle/XmlMessageListenerContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/converter/oracle/MappingAdtMessageConverter.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/converter/oracle/MappingAdtMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/converter/oracle/XmlMessageConverter.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/converter/oracle/XmlMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/DatumMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/DatumMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/OraDataFactory.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/OraDataFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/StructDatumMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/jms/support/oracle/StructDatumMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/retry/oracle/RacFailoverRetryPolicy.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/retry/oracle/RacFailoverRetryPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/retry/oracle/RacRetryOperationsInterceptor.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/retry/oracle/RacRetryOperationsInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/AbstractXmlTypeHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/AbstractXmlTypeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/BeanPropertyStructMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/BeanPropertyStructMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/DocumentXmlTypeHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/DocumentXmlTypeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlObjectMappingHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlObjectMappingHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeMarshallingValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeMarshallingValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/OracleXmlTypeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyConnectionPreparer.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyConnectionPreparer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyDataSource.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/ProxyDataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlArrayValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlArrayValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnArray.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnArray.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnSqlData.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnSqlData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnStruct.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnStruct.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnStructArray.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlReturnStructArray.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructArrayValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructArrayValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructValue.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/SqlStructValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StreamXmlTypeHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StreamXmlTypeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StringXmlTypeHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StringXmlTypeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StructMapper.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/StructMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/XmlTypeHandler.java
+++ b/spring-data-oracle/src/main/java/org/springframework/data/jdbc/support/oracle/XmlTypeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/aop/ConnectionInterceptorTests.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/aop/ConnectionInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/aop/CountingConnectionPreparer.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/aop/CountingConnectionPreparer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/config/oracle/DataOrclNamespaceTests.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/config/oracle/DataOrclNamespaceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/CurrentUsernamePasswordProvider.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/CurrentUsernamePasswordProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/CurrentUsernameProvider.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/CurrentUsernameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/OracleDataSourceFactoryBean.java
+++ b/spring-data-oracle/src/test/java/org/springframework/data/jdbc/test/OracleDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 57 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).