### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
   }
 
   repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
     maven { url "https://repo.spring.io/libs-milestone" }
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.10-bin.zip

--- a/spring-data-oracle-test/build.gradle
+++ b/spring-data-oracle-test/build.gradle
@@ -13,7 +13,7 @@ test {
 
 repositories {
   mavenLocal()
-  mavenCentral()
+  maven { url 'https://repo.maven.apache.org/maven2/' }
   maven { url "https://repo.spring.io/milestone" }
   maven { url "https://repo.spring.io/release" }
   maven { url "https://repo.spring.io/ext-private-local" }


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.